### PR TITLE
Changed assets config to be set within an initializer block

### DIFF
--- a/lib/activeadmin/hstore_editor.rb
+++ b/lib/activeadmin/hstore_editor.rb
@@ -5,7 +5,9 @@ require "activeadmin/resource_dsl"
 module ActiveAdmin
   module HstoreEditor
     class Engine < ::Rails::Engine
-      config.assets.precompile += %w[img/jsoneditor-icons.png]
+      initializer :hstore_editor, group: :all do |app|
+        config.assets.precompile += %w[img/jsoneditor-icons.png]
+      end
 
       rake_tasks do
         task 'assets:precompile' do


### PR DESCRIPTION
This measure was taken because Rails fails to load due to missing `assets` attribute for `Rails::Railtie::Configuration`, which throws an error, at least for `Rails 3.2.21`